### PR TITLE
added env.docker export in down shell script as well to accommodate setting IPAM subnet in docker-compose.yml

### DIFF
--- a/dev_down.sh
+++ b/dev_down.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
+set -e
+
+set -o allexport
+source env.docker
+set +o allexport
 
 docker-compose -f docker-compose.yml down

--- a/prod_down.sh
+++ b/prod_down.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
+set -e
+
+set -o allexport
+source env.docker
+set +o allexport
 
 docker-compose -f docker-compose.yml -f nginx/docker-compose.yml down


### PR DESCRIPTION
@luthfib Turns out env.docker has to be exported in down scripts as well to accommodate setting IPAM subnet in docker-compose.yml. Please take a quick look at the PR and approve it if it looks good to you.