### PR TITLE
fix the issue #379 to make image build in dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.8-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
@krobasky I fixed the dockerhub image build issue for this tx-autht repo by tagging the base image specifically to python:3.8-alpine. The root cause for the build issue is that python:3-alpine was recently updated to have python 3.9 installed which is not compatible with the gevent version we are using. The reason that this issue does not happen in my local development environment but happens in dockerhub and the auth-fuse-dev VM is that I have an old python:3-alpine image in my local development environment which still has python 3.8 installed, so the updated python:3-alpine that has python 3.9 installed is not pulled. The fix is to tag the image specifically to python:3.8-alpine to make sure python version 3.8 image is pulled. I believe this should fix the image build issue. 